### PR TITLE
Add test mode and email listing

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 Role Based Newsletter
 =====================
 
-Dieses Plugin ermöglicht das Versenden von Newsletter-E-Mails an Benutzer anhand ihrer Rolle. Rufen Sie im Admin-Menü **Rollen Newsletter** auf, verfassen Sie Ihre Nachricht und wählen Sie die Rolle **Kunde** aus. Der Versand erfolgt anschließend über `wp_mail()`.
+Dieses Plugin ermöglicht das Versenden von Newsletter-E-Mails an Benutzer anhand ihrer Rolle. Rufen Sie im Admin-Menü **Rollen Newsletter** auf, verfassen Sie Ihre Nachricht und wählen Sie die Rolle **Kunde** aus. Der Versand erfolgt anschließend über `wp_mail()`. Erfolgreich versendete Adressen werden anschließend aufgelistet. Zudem gibt es einen Testmodus, in dem die E-Mail nur an einen ausgewählten Benutzer gesendet wird.
 

--- a/role-based-newsletter.php
+++ b/role-based-newsletter.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * Plugin Name: Role Based Newsletter
- * Description: Send newsletter emails to users filtered by role.
- * Version: 1.0.0
+ * Description: Send newsletter emails to users filtered by role. Includes a test mode and shows recipients after sending.
+ * Version: 1.1.0
  * Author: Codex Agent
  */
 
@@ -32,10 +32,13 @@ class Role_Based_Newsletter {
         }
 
         if ( isset( $_POST['rbn_submit'] ) && check_admin_referer( 'rbn_send_newsletter', 'rbn_nonce' ) ) {
-            $subject = sanitize_text_field( wp_unslash( $_POST['rbn_subject'] ) );
-            $content = wp_kses_post( wp_unslash( $_POST['rbn_content'] ) );
-            $role    = sanitize_text_field( wp_unslash( $_POST['rbn_role'] ) );
-            $this->send_newsletter( $subject, $content, $role );
+            $subject   = sanitize_text_field( wp_unslash( $_POST['rbn_subject'] ) );
+            $content   = wp_kses_post( wp_unslash( $_POST['rbn_content'] ) );
+            $role      = sanitize_text_field( wp_unslash( $_POST['rbn_role'] ) );
+            $test_mode = isset( $_POST['rbn_test_mode'] );
+            $test_user = isset( $_POST['rbn_test_user'] ) ? absint( $_POST['rbn_test_user'] ) : 0;
+
+            $this->send_newsletter( $subject, $content, $role, $test_mode, $test_user );
         }
         ?>
         <div class="wrap">
@@ -56,7 +59,21 @@ class Role_Based_Newsletter {
                         <td>
                             <select name="rbn_role" id="rbn_role" required>
                                 <?php foreach ( $roles as $role_key => $role_name ) : ?>
-                                    <option value="<?php echo esc_attr( $role_key ); ?>"><?php echo esc_html( $role_name ); ?></option>
+                                    <option value="<?php echo esc_attr( $role_key ); ?>" <?php selected( isset( $_POST['rbn_role'] ) && $_POST['rbn_role'] === $role_key ); ?>><?php echo esc_html( $role_name ); ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><label for="rbn_test_mode"><?php esc_html_e( 'Testmodus', 'rbn' ); ?></label></th>
+                        <td><label><input type="checkbox" name="rbn_test_mode" id="rbn_test_mode" value="1" <?php checked( ! empty( $_POST['rbn_test_mode'] ) ); ?> /> <?php esc_html_e( 'Nur an ausgewählten Benutzer senden', 'rbn' ); ?></label></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><label for="rbn_test_user"><?php esc_html_e( 'Testbenutzer', 'rbn' ); ?></label></th>
+                        <td>
+                            <select name="rbn_test_user" id="rbn_test_user">
+                                <?php foreach ( get_users() as $user ) : ?>
+                                    <option value="<?php echo esc_attr( $user->ID ); ?>" <?php selected( isset( $_POST['rbn_test_user'] ) && absint( $_POST['rbn_test_user'] ) === $user->ID ); ?>><?php echo esc_html( $user->user_email ); ?></option>
                                 <?php endforeach; ?>
                             </select>
                         </td>
@@ -68,12 +85,34 @@ class Role_Based_Newsletter {
         <?php
     }
 
-    private function send_newsletter( $subject, $content, $role ) {
-        $users = get_users( array( 'role' => $role ) );
-        foreach ( $users as $user ) {
-            wp_mail( $user->user_email, $subject, $content, array( 'Content-Type: text/html; charset=UTF-8' ) );
+    private function send_newsletter( $subject, $content, $role, $test_mode = false, $test_user = 0 ) {
+        $sent_emails = array();
+
+        if ( $test_mode && $test_user ) {
+            $user = get_user_by( 'id', $test_user );
+            if ( $user ) {
+                if ( wp_mail( $user->user_email, $subject, $content, array( 'Content-Type: text/html; charset=UTF-8' ) ) ) {
+                    $sent_emails[] = $user->user_email;
+                }
+            }
+        } else {
+            $users = get_users( array( 'role' => $role ) );
+            foreach ( $users as $user ) {
+                if ( wp_mail( $user->user_email, $subject, $content, array( 'Content-Type: text/html; charset=UTF-8' ) ) ) {
+                    $sent_emails[] = $user->user_email;
+                }
+            }
         }
-        echo '<div class="updated"><p>' . esc_html__( 'Newsletter an Rolle ', 'rbn' ) . esc_html( $role ) . esc_html__( ' gesendet.', 'rbn' ) . '</p></div>';
+
+        if ( $sent_emails ) {
+            echo '<div class="updated"><p>' . esc_html__( 'Newsletter gesendet an:', 'rbn' ) . '</p><ul>';
+            foreach ( $sent_emails as $mail ) {
+                echo '<li>' . esc_html( $mail ) . '</li>';
+            }
+            echo '</ul></div>';
+        } else {
+            echo '<div class="error"><p>' . esc_html__( 'Keine E-Mails gesendet.', 'rbn' ) . '</p></div>';
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- show a checkbox and dropdown to use a test mode
- display successfully sent email addresses after sending
- update plugin version and readme

## Testing
- `php -l role-based-newsletter.php`

------
https://chatgpt.com/codex/tasks/task_e_6873e24d0858832fa111c6c4e3708f51